### PR TITLE
Add `gem install foreman` to the bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -11,6 +11,7 @@ Dir.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system "gem install bundler --conservative"
   system "bundle check || bundle install"
+  system "gem install foreman"
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
`foreman` is required to start the application, and should be added as a dependency in the `bin/setup`.
