### PR TITLE
Add an optional email to user.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,10 @@ class User < ActiveRecord::Base
   has_secure_password
 
   validates :username, presence: true, uniqueness: true
+  validates :email,
+            format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i },
+            unless: -> { email.blank? }
+  validates :email, uniqueness: true, unless: -> { email.blank? }
 
   has_many :players
 end

--- a/app/resources/v1/user_resource.rb
+++ b/app/resources/v1/user_resource.rb
@@ -3,13 +3,15 @@ module V1
 
     attribute :username
 
+    attribute :email
+
     attribute :password
 
     attribute :pit_boss
 
     class << self
       def creatable_fields(context)
-        fields = [:username, :password]
+        fields = [:username, :email, :password]
         if context && context[:current_user] && context[:current_user].pit_boss?
           fields += [:pit_boss]
         end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -2,8 +2,13 @@ Doorkeeper.configure do
   orm :active_record
 
   resource_owner_from_credentials do
+    query = if params[:email].present?
+              { email: params[:email] }
+            else
+              { username: params[:username] }
+            end
     current_user ||= begin
-      user = User.find_by(username: params[:username])
+      user = User.find_by(query)
       user && user.authenticate(params[:password])
     end
   end

--- a/db/migrate/20150917162709_add_email_to_users.rb
+++ b/db/migrate/20150917162709_add_email_to_users.rb
@@ -1,0 +1,6 @@
+class AddEmailToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :email, :string
+    add_index :users, :email, unique: true, where: "email IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150917151639) do
+ActiveRecord::Schema.define(version: 20150917162709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,8 +211,10 @@ ActiveRecord::Schema.define(version: 20150917151639) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.boolean  "pit_boss",        default: false, null: false
+    t.string   "email"
   end
 
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)", using: :btree
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "wagers", force: :cascade do |t|

--- a/spec/acceptance/oauth_tokens_spec.rb
+++ b/spec/acceptance/oauth_tokens_spec.rb
@@ -10,6 +10,53 @@ RSpec.resource "OAuth Tokens" do
     end
 
     let! :user do
+      FactoryGirl.create(:user, username: username, password: password)
+    end
+
+    parameter "grant_type", <<-DESC, required: true
+      The OAuth2 grant type. Must be <code>password</code>.
+    DESC
+
+    let "grant_type" do
+      "password"
+    end
+
+    parameter "username", <<-DESC, required: true
+      The username of the user.
+    DESC
+
+    let "username" do
+      "sean"
+    end
+
+    parameter "password", <<-DESC, required: true
+      The password of the user.
+    DESC
+
+    let "password" do
+      "drowssap"
+    end
+
+    example_request "POST /oauth/token with username" do
+      explanation "Authenticate through OAuth using username."
+      expect(status).to eq 200
+      expect(JSON.parse(response_body)["access_token"]).not_to be_nil
+    end
+
+    after do
+      RspecApiDocumentation.configuration.post_body_formatter = @post_body_formatter
+    end
+  end
+
+  post "/oauth/token" do
+    before do
+      @post_body_formatter = RspecApiDocumentation.configuration.post_body_formatter.dup
+      RspecApiDocumentation.configuration.post_body_formatter = proc do |params|
+        params
+      end
+    end
+
+    let! :user do
       FactoryGirl.create(:user, username: username, password: password, email: email)
     end
 
@@ -21,15 +68,11 @@ RSpec.resource "OAuth Tokens" do
       "password"
     end
 
-    parameter "username", <<-DESC
-      The username of the user.
-    DESC
-
     let "username" do
       "sean"
     end
 
-    parameter "email", <<-DESC
+    parameter "email", <<-DESC, required: true
       The email of the user.
     DESC
 
@@ -45,7 +88,8 @@ RSpec.resource "OAuth Tokens" do
       "drowssap"
     end
 
-    example_request "POST /oauth/token" do
+    example_request "POST /oauth/token with email" do
+      explanation "Authenticate through OAuth using email."
       expect(status).to eq 200
       expect(JSON.parse(response_body)["access_token"]).not_to be_nil
     end

--- a/spec/acceptance/oauth_tokens_spec.rb
+++ b/spec/acceptance/oauth_tokens_spec.rb
@@ -10,7 +10,7 @@ RSpec.resource "OAuth Tokens" do
     end
 
     let! :user do
-      FactoryGirl.create(:user, username: username, password: password)
+      FactoryGirl.create(:user, username: username, password: password, email: email)
     end
 
     parameter "grant_type", <<-DESC, required: true
@@ -21,12 +21,20 @@ RSpec.resource "OAuth Tokens" do
       "password"
     end
 
-    parameter "username", <<-DESC, required: true
+    parameter "username", <<-DESC
       The username of the user.
     DESC
 
     let "username" do
       "sean"
+    end
+
+    parameter "email", <<-DESC
+      The email of the user.
+    DESC
+
+    let "email" do
+      "david@example.com"
     end
 
     parameter "password", <<-DESC, required: true

--- a/spec/acceptance/users_spec.rb
+++ b/spec/acceptance/users_spec.rb
@@ -20,6 +20,14 @@ RSpec.resource "Users", :authenticated, :authorized do
       "sean"
     end
 
+    parameter "email", <<-DESC, scope: :attributes
+      The **unique** (if provided) email address for the user.
+    DESC
+
+    let "email" do
+      "david@example.com"
+    end
+
     parameter "password", <<-DESC, required: true, scope: :attributes
       The password with which the user with authenticate.
     DESC
@@ -90,6 +98,14 @@ RSpec.resource "Users", :authenticated, :authorized do
 
     let "username" do
       "seand"
+    end
+
+    parameter "email", <<-DESC, scope: :attributes
+      The **unique** (if provided) email address for the user.
+    DESC
+
+    let "email" do
+      "david@example.com"
     end
 
     parameter "password", <<-DESC, scope: :attributes

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,9 @@ FactoryGirl.define do
   factory :user do
     sequence(:username) { |n| "sean-#{n}" }
     password "drowssap"
+
+    trait :with_email do
+      sequence(:email) { |n| "david#{"+#{n}" if n > 0}@example.com" }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,10 +4,30 @@ RSpec.describe User do
     expect(subject.username).to eq "sean"
   end
 
+  it "has an email attribute" do
+    subject.email = "david@example.com"
+    expect(subject.email).to eq "david@example.com"
+  end
+
   it "validates the presence of username" do
     subject.username = nil
     subject.valid?
     expect(subject.errors[:username]).to include "can't be blank"
+  end
+
+  it "does not enforce the presence of email" do
+    subject.email = nil
+    subject.valid?
+    expect(subject.errors[:email]).to be_empty
+  end
+
+  it "validates email format if any" do
+    subject.email = "invalid"
+    subject.valid?
+    expect(subject.errors[:email]).to include "is invalid"
+    subject.email = "david@example.com"
+    subject.valid?
+    expect(subject.errors[:email]).to be_empty
   end
 
   it "has the pit_boss attribute" do
@@ -36,5 +56,25 @@ RSpec.describe User do
     original = FactoryGirl.create(:user, username: "foo")
     duplicate = FactoryGirl.create(:user, username: "bar")
     expect{duplicate.update_column(:username, original.username)}.to raise_error ActiveRecord::RecordNotUnique
+  end
+
+  it "validates the uniqueness of email when present" do
+    original = FactoryGirl.create(:user, :with_email)
+    duplicate = FactoryGirl.build(:user, email: original.email)
+    duplicate.valid?
+    expect(duplicate.errors[:email]).to include "has already been taken"
+  end
+
+  it "doesn't fail on email uniqueness when empty" do
+    original = FactoryGirl.create(:user)
+    duplicate = FactoryGirl.build(:user)
+    duplicate.valid?
+    expect(duplicate.errors[:email]).to be_empty
+  end
+
+  it "has a unique index on email in the database" do
+    original = FactoryGirl.create(:user, :with_email)
+    duplicate = FactoryGirl.create(:user, :with_email)
+    expect{duplicate.update_column(:email, original.email)}.to raise_error ActiveRecord::RecordNotUnique
   end
 end

--- a/spec/resources/v1/user_resource_spec.rb
+++ b/spec/resources/v1/user_resource_spec.rb
@@ -4,7 +4,8 @@ module V1
     let :creatable_and_updatable_fields do
       [
         :username,
-        :password
+        :password,
+        :email
       ].sort
     end
 


### PR DESCRIPTION
Why?
- We might want to contact the user in the future.

How?
- Added an optional email field to User.
- Added to resource.
- Added tests.
- Changed Doorkeeper settings to accept either email or username.

To do/discuss:
- How to document the fact that one of username OR email is required on
  /oauth/token endpoint?
- How to add end-to-end tests with email login, without altering existing one?
