### PR TITLE
Add pagination of players

### DIFF
--- a/app/resources/v1/player_resource.rb
+++ b/app/resources/v1/player_resource.rb
@@ -7,6 +7,8 @@ module V1
 
     filter :name
 
+    paginator :paged
+
     class << self
       def creatable_fields(context)
         [

--- a/spec/acceptance/players_spec.rb
+++ b/spec/acceptance/players_spec.rb
@@ -87,6 +87,13 @@ RSpec.resource "Players", :authenticated, :authorized do
       expect(JSON.parse(response_body)["data"].size).to eq 0
     end
 
+    example_request "GET /v1/players" do
+      expect(status).to eq 200
+      expect(JSON.parse(response_body)["data"].size).to eq 1
+    end
+  end
+
+  get "/v1/players" do
     example "GET /v1/players?page=1" do
       FactoryGirl.create_list(:player, 10)
       do_request({ page: {number: "1", size: "5"} })
@@ -99,12 +106,7 @@ RSpec.resource "Players", :authenticated, :authorized do
       FactoryGirl.create_list(:player, 2)
       do_request({ page: {number: "2", size: 5} })
       expect(status).to eq 200
-      expect(JSON.parse(response_body)["data"].size).to eq 3
-    end
-
-    example_request "GET /v1/players" do
-      expect(status).to eq 200
-      expect(JSON.parse(response_body)["data"].size).to eq 1
+      expect(JSON.parse(response_body)["data"].size).to eq 2
     end
   end
 

--- a/spec/acceptance/players_spec.rb
+++ b/spec/acceptance/players_spec.rb
@@ -87,6 +87,20 @@ RSpec.resource "Players", :authenticated, :authorized do
       expect(JSON.parse(response_body)["data"].size).to eq 0
     end
 
+    example "GET /v1/players?page=1" do
+      FactoryGirl.create_list(:player, 55)
+      do_request({ page: "1" })
+      expect(status).to eq 200
+      expect(JSON.parse(response_body)["data"].size).to eq 10
+    end
+
+    example "GET /v1/players?page=6" do
+      FactoryGirl.create_list(:player, 55)
+      do_request({ page: "6" })
+      expect(status).to eq 200
+      expect(JSON.parse(response_body)["data"].size).to eq 6
+    end
+
     example_request "GET /v1/players" do
       expect(status).to eq 200
       expect(JSON.parse(response_body)["data"].size).to eq 1

--- a/spec/acceptance/players_spec.rb
+++ b/spec/acceptance/players_spec.rb
@@ -88,7 +88,7 @@ RSpec.resource "Players", :authenticated, :authorized do
     end
 
     example "GET /v1/players?page=1" do
-      FactoryGirl.create_list(:player, 55)
+      FactoryGirl.create_list(:player, 10)
       do_request({ page: {number: "1", size: "5"} })
       expect(status).to eq 200
       expect(JSON.parse(response_body)["data"].size).to eq 5

--- a/spec/acceptance/players_spec.rb
+++ b/spec/acceptance/players_spec.rb
@@ -89,16 +89,17 @@ RSpec.resource "Players", :authenticated, :authorized do
 
     example "GET /v1/players?page=1" do
       FactoryGirl.create_list(:player, 55)
-      do_request({ page: "1" })
+      do_request({ page: {number: "1", size: "5"} })
       expect(status).to eq 200
-      expect(JSON.parse(response_body)["data"].size).to eq 10
+      expect(JSON.parse(response_body)["data"].size).to eq 5
     end
 
-    example "GET /v1/players?page=6", document: false do
-      FactoryGirl.create_list(:player, 55)
-      do_request({ page: "6" })
+    example "GET /v1/players?page=2", document: false do
+      FactoryGirl.create_list(:player, 5)
+      FactoryGirl.create_list(:player, 2)
+      do_request({ page: {number: "2", size: 5} })
       expect(status).to eq 200
-      expect(JSON.parse(response_body)["data"].size).to eq 6
+      expect(JSON.parse(response_body)["data"].size).to eq 3
     end
 
     example_request "GET /v1/players" do

--- a/spec/acceptance/players_spec.rb
+++ b/spec/acceptance/players_spec.rb
@@ -94,7 +94,7 @@ RSpec.resource "Players", :authenticated, :authorized do
       expect(JSON.parse(response_body)["data"].size).to eq 10
     end
 
-    example "GET /v1/players?page=6" do
+    example "GET /v1/players?page=6", document: false do
       FactoryGirl.create_list(:player, 55)
       do_request({ page: "6" })
       expect(status).to eq 200


### PR DESCRIPTION
Areas for review:
- I'm using the default page size of 10. I didn't want to change the JSON API config, but couldn't figure out how to change the page size on the resource. the `paginator` method takes only one parameter.
- The `page 6` test expects 6 players, even though I created only 55 – since the `let!` block creates one more. (and I should change the numbers since the sixes are coincidental)
- The test for page 6 should be somewhere else or different syntax, since it isn't a documentation example.
